### PR TITLE
Print error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@
 extern crate riffol;
 extern crate stderrlog;
 
+use std::process::exit;
+
 fn main() {
     stderrlog::new()
         .module(module_path!())
@@ -32,7 +34,10 @@ fn main() {
         .unwrap();
 
     match riffol::riffol(std::env::args()) {
-        Err(e) => eprintln!("{:?}", e),
+        Err(e) => {
+            eprintln!("{:?}", e);
+            exit(1);
+        }
         _ => (),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,5 +31,8 @@ fn main() {
         .init()
         .unwrap();
 
-    riffol::riffol(std::env::args()).ok();
+    match riffol::riffol(std::env::args()) {
+        Err(e) => eprintln!("{:?}", e),
+        _ => (),
+    }
 }


### PR DESCRIPTION
In response to Issue #45, this will print the error message instead of just failing silently